### PR TITLE
Move mod & senior mod perms to global realm

### DIFF
--- a/models/groups/moderators.yml
+++ b/models/groups/moderators.yml
@@ -9,7 +9,7 @@ minecraft_flair:
     symbol: "[Mod] "
     color: red
 minecraft_permissions: 
-  normal: 
+  global: 
     - skin.change
     - chat.admin
     - chatmoderator.filters.exempt

--- a/models/groups/senior_moderators.yml
+++ b/models/groups/senior_moderators.yml
@@ -8,7 +8,7 @@ minecraft_flair:
     symbol: "[SrMod]"
     color: dark_red
 minecraft_permissions:
-  normal:
+  global:
   - bukkit.command.stop
   - chat.admin
   - chatmoderator.filters.exempt


### PR DESCRIPTION
Move moderator and senior moderator permissions from the 'normal' realm to the 'global' realm. This should fix issues relating to moderation staff being able to see through nicknames, etc. and makes it consistent with the junior mod permissions.