### PR TITLE
Update trophy icons for kills

### DIFF
--- a/models/trophies/100k-kills.yml
+++ b/models/trophies/100k-kills.yml
@@ -1,3 +1,3 @@
 name: 100k kills
 description: Achieved 100k kills
-css_class: fa-trophy
+css_class: fa-star

--- a/models/trophies/10k-kills.yml
+++ b/models/trophies/10k-kills.yml
@@ -1,3 +1,3 @@
 name: 10k kills
 description: Achieved 10k kills
-css_class: fa-trophy
+css_class: fa-star


### PR DESCRIPTION
Tournament winner trophy should not have the same icon as the ones for 10k and 100k kills. There isn't really a trophy that would fit the kills but I think this one might be one of the better ones.