### PR TITLE
Add Beta Participant trophy

### DIFF
--- a/models/trophies/beta-participant.yml
+++ b/models/trophies/beta-participant.yml
@@ -1,0 +1,3 @@
+name: Beta Participant
+description: Participate in the beta system
+css_class: fa-bug


### PR DESCRIPTION
Beta Participant trophy is automated and works similarly to the Sapper trophy. If a user is participating in the beta program, they get this trophy. If they stop the trophy is removed from them.

Part of https://github.com/StratusNetwork/OCN/pull/23