### PR TITLE
Allow Head Map Dev to manage Develop subforum

### DIFF
--- a/models/groups/senior_map_developer.yml
+++ b/models/groups/senior_map_developer.yml
@@ -6,6 +6,8 @@ web_permissions:
       manage: true
     59ac44fba2e3a9000100004c: #Stratus_Network/Applications
       manage: true
+    59b41b2b66bbaa0001000005: #Community/Development
+      manage: true
   group: 
     parent:
       admin: true


### PR DESCRIPTION
I believe that this subforum can be used for more than reporting bugs and some ideas. I was thinking of being able to have head map developers involved with more cooperation towards sectors and have it serve as for open discussions on certain topics. As head map developers are also senior staff and work closely with developers, I see it as appropriate if head map developers can serve in such ways.