### PR TITLE
Create a trophy for achieving 50k kills

### DIFF
--- a/models/trophies/50k-kills.yml
+++ b/models/trophies/50k-kills.yml
@@ -1,0 +1,3 @@
+name: 50k kills
+description: Achieved 50k kills
+css_class: fa-trophy


### PR DESCRIPTION
A milestone alongside 10k and 100k, 50k should be recognized in between as it is a realistic and more motivational goal to work towards. People are already above 25k.