### PR TITLE
Remove Christmas dungeon trophy

### DIFF
--- a/models/trophies/holiday-savior.yml
+++ b/models/trophies/holiday-savior.yml
@@ -1,3 +1,0 @@
-name: Holiday Savior
-description: Complete the 2017 Christmas dungeon
-css_class: fa fa-gift


### PR DESCRIPTION
The dungeon event didn't end up happening so this trophy is no longer needed.