### PR TITLE
Readd MapDev Tag

### DIFF
--- a/models/groups/map_developers.yml
+++ b/models/groups/map_developers.yml
@@ -3,6 +3,10 @@ priority: 360
 html_color: "#283593"
 badge_color: "#283593"
 badge_link: "/staff"
+minecraft_flair:
+  normal:
+    color: blue
+    symbol: "[MapDev] "
 staff: true
 web_permissions:
   forum:


### PR DESCRIPTION
MapDevs need to have a tag in-game if they aren't otherwise a mod, in the cases of setnext events, public map testings, players reporting map bugs directly in-game, etc.