### PR TITLE
Allow senior moderators to shuffle teams

### DIFF
--- a/models/groups/senior_moderators.yml
+++ b/models/groups/senior_moderators.yml
@@ -82,6 +82,7 @@ minecraft_permissions:
   - pgm.start
   - pgm.team.alias
   - pgm.team.force
+  - pgm.team.shuffle
   - pgm.team.size
   - pgm.timelimit
   - pgm.updatemap


### PR DESCRIPTION
Not sure if it matters, however I noticed that moderators have this permission while Srs do not.