### PR TITLE
Readd developer tags at a higher priority than mod tags

### DIFF
--- a/models/groups/developers.yml
+++ b/models/groups/developers.yml
@@ -26,3 +26,8 @@ minecraft_permissions:
   - tokens.give
   - whitelist.bypass
 staff: true
+minecraft_flair:
+  global:
+    symbol: "[Dev] "
+    color: dark_purple
+    priority: 360

--- a/models/groups/junior_developers.yml
+++ b/models/groups/junior_developers.yml
@@ -68,6 +68,11 @@ minecraft_permissions:
   - worldedit.*
   - worldedit.wand
 staff: true
+minecraft_flair:
+  normal:
+    symbol: "[Dev] "
+    color: light_purple
+    priority: 370
 premium: true
 web_permissions:
   forum:

--- a/models/groups/map_developers.yml
+++ b/models/groups/map_developers.yml
@@ -1,5 +1,5 @@
 name: Map Developers
-priority: 360
+priority: 380
 html_color: "#283593"
 badge_color: "#283593"
 badge_link: "/staff"


### PR DESCRIPTION
All mod tags would show instead of these tags if the user in question has both ranks. The website priority would stay unchanged.