### PR TITLE
Give Livestreamers and Co-streamers Gamemode Change Perms

### DIFF
--- a/models/groups/co_streamer.yml
+++ b/models/groups/co_streamer.yml
@@ -3,6 +3,7 @@ priority: 575
 minecraft_permissions:
   tournament:
   - commandbook.gamemode
+  - commandbook.gamemode.change
   - "-channels.global.send"
   - pgm.chat.all.receive
   - whitelist.bypass

--- a/models/groups/live_streamer.yml
+++ b/models/groups/live_streamer.yml
@@ -3,6 +3,7 @@ priority: 550
 minecraft_permissions:
   tournament:
   - commandbook.gamemode
+  - commandbook.gamemode.change
   - "-channels.global.send"
   - pgm.chat.all.receive
   - whitelist.bypass


### PR DESCRIPTION
Will allow live/co-streamers to switch to gamemode 3 while streaming tournaments