### PR TITLE
Halloween perms

### DIFF
--- a/models/groups/senior_map_developer.yml
+++ b/models/groups/senior_map_developer.yml
@@ -33,6 +33,11 @@ web_permissions:
       manage: true
       edit:
         members: true
+    ghosts:
+      admin: true
+      manage: true
+      edit:
+        members: true
   user:
     profile:
       verified:

--- a/models/trophies/dungeon-mastermind.yml
+++ b/models/trophies/dungeon-mastermind.yml
@@ -1,0 +1,4 @@
+name: Dungeon Mastermind
+description: Conquer the 2018 Halloween dungeon
+priority: 41
+css_class: fa fa-dungeon


### PR DESCRIPTION
Adds `Dungeon Mastermind` trophy and allows Senior Map Developers to give out the Ghosts gizmo for the Halloween event. The trophy requires https://github.com/StratusNetwork/web/pull/24 to be accepted for the icon to work.