### PR TITLE
Allow Map Developers to edit their verified info

### DIFF
--- a/models/groups/map_developers.yml
+++ b/models/groups/map_developers.yml
@@ -81,6 +81,10 @@ web_permissions:
   misc:
     player:
       view_new_players: true
+  user:
+    profile:
+      verified:
+        edit: own
 minecraft_permissions:
   mapdev:
   - commandbook.clear


### PR DESCRIPTION
So we can join the cool kids club and have colourful names on the revisions page. @AustinLMayes had mentioned a potential downside about giving Map Devs these perms but never elaborated. If it doesn't do anything bad, uh, it would be cool to have, pretty please cherry on top?