### PR TITLE
Allow map devs to shuffle teams

### DIFF
--- a/models/groups/map_developers.yml
+++ b/models/groups/map_developers.yml
@@ -130,6 +130,7 @@ minecraft_permissions:
   - pgm.team.alias
   - pgm.team.force
   - pgm.team.size
+  - pgm.team.shuffle
   - pgm.timelimit
   - pgm.updatemap
   - poll.custom


### PR DESCRIPTION
It would be a great perm to have, if possible. Useful when re-balancing teams, without having to force people around. Also great for events (mods have it, why can't we?)