### PR TITLE
Update Anax permissions

### DIFF
--- a/models/groups/_default.yml
+++ b/models/groups/_default.yml
@@ -112,6 +112,7 @@ minecraft_permissions:
   - minecraft.command.selector
   - minecraft.command.tell
   - minecraft.command.xp
+  - network.stratus.login
   - worldedit.navigation.unstuck
   - worldedit.navigation.thru.command
   - worldedit.navigation.jumpto.command

--- a/models/groups/anax_manager.yml
+++ b/models/groups/anax_manager.yml
@@ -9,6 +9,11 @@ web_permissions:
       manage: true
       edit:
         members: true
+    anax_world:
+      admin: true
+      manage: true
+      edit:
+        members: true
 minecraft_permissions:
   anax:
   - anax.admin

--- a/models/groups/anax_world.yml
+++ b/models/groups/anax_world.yml
@@ -1,0 +1,5 @@
+name: Anax World
+priority: 1000
+minecraft_permissions:
+  anax:
+  - anax.world.1

--- a/models/groups/senior_map_developer.yml
+++ b/models/groups/senior_map_developer.yml
@@ -18,6 +18,11 @@ web_permissions:
       manage: true
       edit:
         members: true
+    anax_world:
+      admin: true
+      manage: true
+      edit:
+        members: true
     builders:
       admin: true
       manage: true


### PR DESCRIPTION
Updates Anax permissions to reflect agreed-upon changes. Unsure if the default group requires the `anax.world.0` permission to set their world limit to 0 or if it defaults to 0.