### PR TITLE
Fix observers being able to lookup warns

### DIFF
--- a/models/groups/_observers.yml
+++ b/models/groups/_observers.yml
@@ -22,7 +22,6 @@ minecraft_permissions:
   - nocheatplus.checks.inventory
   - nocheatplus.checks.moving
   - nocheatplus.mods.zombe
-  - ocn.punishments.lookup
   - ocn.teleport
   - pgm.class
   - pgm.class.list


### PR DESCRIPTION
Observers are able to see warns when they do /lookup <user>. This could fix the problem (Though, I'm not sure)
I think that the permission I removed, lets observers check warns. Mods have this perm but the default group doesn't. This would explain why normal players are only able to see warns when they are observers while mods can see them ingame and as observers.