### PR TITLE
Give ECs hosting perms on Private & Ranked servers

### DIFF
--- a/models/groups/event-coordinator.yml
+++ b/models/groups/event-coordinator.yml
@@ -94,6 +94,42 @@ minecraft_permissions:
   - worldedit.wand.toggle
   private:
   - whitelist.bypass
+  - chat.admin
+  - pgm.chat.all.receive
+  - pgm.fullserver
+  - pgm.team.force
+  - setting.adminchat
+  - nick.see-through-all
+  - setting.nick.view
+  - channels.global.send
+  - chat.admin
+  - commandbook.broadcast
+  - commandbook.gamemode
+  - commandbook.gamemode.change
+  - commandbook.time.player
+  - minecraft.command.stop
+  - pgm.cancel
+  - pgm.chat.all.receive
+  - pgm.cycle
+  - pgm.destroyable.edit
+  - pgm.end
+  - pgm.fullserver
+  - pgm.join.force
+  - pgm.next.set
+  - pgm.skip
+  - pgm.start
+  - pgm.team.alias
+  - pgm.team.force
+  - pgm.team.size
+  - pgm.timelimit
+  - projectares.freeze.exempt
+  - projectares.staff
+  - server.cancelrestart
+  - server.queuerestart
+  - server.restart
+  - server.visibility
+  - whitelist.bypass
+  - whitelist.edit
   practice:
   - bukkit.command.stop
   - chat.admin


### PR DESCRIPTION
Pretty please it's helpful especially to look around at maps and such.  I don't know if these perms let me /request a private server to look at maps & run map-tests or not, but that'd be kinda sick too (though I assume there's discussion behind that one, but consider it?).

Btw I just copy-pasted all the perms under "private" from the Host perms page: https://github.com/StratusNetwork/data/blob/master/models/groups/host.yml